### PR TITLE
fix(test): use vm prank

### DIFF
--- a/test/XGreeter.t.sol
+++ b/test/XGreeter.t.sol
@@ -52,6 +52,7 @@ contract XGreeterTest is Test {
         emit Greetings(sender, sourceChainId, greeting);
 
         // use portal.mockXCall to simulate an xcall to xgreeter.greet(...)
+        vm.prank(sender);
         portal.mockXCall(sourceChainId, sender, address(xgreeter), abi.encodeWithSignature("greet(string)", greeting));
     }
 


### PR DESCRIPTION
use vm.prank() in test now that mock portal xcall that uses msg.sender

task: none